### PR TITLE
Add ability to specify detailed basis set within the schema

### DIFF
--- a/qc_schema/dev/definitions.py
+++ b/qc_schema/dev/definitions.py
@@ -44,22 +44,11 @@ definitions["basis_electron_shell"] = {
     "description": "Information for a single electronic shell",
     "additionalProperties": False,
     "required": [
-        "shell_harmonic_type",
         "shell_angular_momentum",
         "shell_exponents",
         "shell_coefficients"
     ],
     "properties": {
-        "shell_function_type": {
-            "description": "Type of function for this shell",
-            "type": "string",
-            "enum": [ "gto", "sto" ]
-        },
-        "shell_harmonic_type": {
-            "description": "Harmonic type (spherical, cartesian)",
-            "type": "string",
-            "enum": [ "spherical", "cartesian" ]
-        },
         "shell_region": {
             "description": "The region this shell describes",
             "type": "string",
@@ -195,6 +184,16 @@ definitions["basis_spec"] = {
             "description": "Brief description of the basis set",
             "type": "string"
         },  
+        "basis_function_type": {
+            "description": "Type of function for this basis",
+            "type": "string",
+            "enum": [ "gto", "sto" ]
+        },
+        "basis_harmonic_type": {
+            "description": "Harmonic type (spherical, cartesian)",
+            "type": "string",
+            "enum": [ "spherical", "cartesian" ]
+        },
         "basis_set_elements": {
             "description": "Per-element basis data",
             "type": "object",

--- a/qc_schema/dev/definitions.py
+++ b/qc_schema/dev/definitions.py
@@ -39,3 +39,183 @@ definitions["provenance"] = {
     "description": "A short provenance of the object.",
     "additionalProperties": True
 }
+
+definitions["basis_electron_shell"] = {
+    "description": "Information for a single electronic shell",
+    "additionalProperties": False,
+    "required": [
+        "shell_harmonic_type",
+        "shell_angular_momentum",
+        "shell_exponents",
+        "shell_coefficients"
+    ],
+    "properties": {
+        "shell_function_type": {
+            "description": "Type of function for this shell",
+            "type": "string",
+            "enum": [ "gto", "sto" ]
+        },
+        "shell_harmonic_type": {
+            "description": "Harmonic type (spherical, cartesian)",
+            "type": "string",
+            "enum": [ "spherical", "cartesian" ]
+        },
+        "shell_region": {
+            "description": "The region this shell describes",
+            "type": "string",
+            "enum": [ "valence", "polarization", "core", "tight", "diffuse" ]
+        },
+        "shell_angular_momentum": {
+            "description": "Angular momentum (as an array of integers)",
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": True,
+            "items": {
+                "type": "integer",
+                "minimum": 0
+            }
+
+        },
+        "shell_exponents": {
+            "description": "Exponents for this contracted shell",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "string"
+            }
+        },
+        "shell_coefficients": {
+            "description": "General contraction coefficients for this contracted shell",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "description": "Segmented contraction coefficients",
+                "type": "array",
+                "minItems": 1,
+                "items": { "type": "string" }
+            }
+        }
+    }
+}
+
+definitions["basis_ecp_potential"] = {
+    "description": "ECP potential",
+    "additionalProperties": False,
+    "required": [
+        "potential_ecp_type",
+        "potential_angular_momentum",
+        "potential_r_exponents",
+        "potential_gaussian_exponents",
+        "potential_coefficients"
+    ],
+    "properties": {
+        "potential_ecp_type": {
+            "description": "Type of the ECP Potential",
+            "type": "string",
+            "enum": [ "scalar", "spinorbit" ]
+        },
+        "potential_angular_momentum": {
+            "description": "Angular momentum (as an array of integers)",
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": True,
+            "items": {
+                "type": "integer",
+                "minimum": 0
+            }
+        },
+        "potential_r_exponents": {
+            "description": "Exponents of the r term",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "integer"
+            }
+        },
+        "potential_gaussian_exponents": {
+            "description": "Exponents of the gaussian term",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "string"
+            }
+        },
+        "potential_coefficients": {
+            "description": "General contraction coefficients for this contracted shell",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "description": "Segmented contraction coefficients",
+                "type": "array",
+                "minItems": 1,
+                "items": { "type": "string" }
+            }
+        }
+    }
+}
+
+
+definitions["basis_single_data"] = {
+    "description": "Data for a single element or atom in the basis set",
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "element_electron_shells": {
+            "description": "(Electronic) shells for this element",
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": True,
+            "items": {
+                "$ref": "#/definitions/basis_electron_shell"
+            }
+        },
+        "element_ecp_electrons":
+        {
+            "description": "Number of electrons replaced by ECP",
+            "type": "integer",
+            "minimum": 1
+        },
+        "element_ecp": {
+            "description": "Effective Core Potential for this element",
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": True,
+            "items": {
+                "$ref": "#/definitions/basis_ecp_potential"
+            }
+        }
+    }
+}
+
+definitions["basis_spec"] = {
+    "description": "Specification for a basis applied to a molecule",
+    "type": "object",
+    "additionalProperties": False,
+    "properties":
+    {
+        "basis_set_description": {
+            "description": "Brief description of the basis set",
+            "type": "string"
+        },  
+        "basis_set_elements": {
+            "description": "Per-element basis data",
+            "type": "object",
+            "additionalProperties": False,
+            "patternProperties":   {   
+                "^\\d+$" : { 
+                    "$ref" : "#/definitions/basis_single_data"
+                }   
+            }   
+        },  
+        "basis_set_atoms": {
+            "description": "Basis set overrides for particular atoms or centers",
+            "type": "object",
+            "additionalProperties": False,
+            "patternProperties":   {   
+                "^\\d+$" : { 
+                    "$ref" : "#/definitions/basis_single_data"
+                }   
+            }   
+        }   
+    }
+}

--- a/qc_schema/dev/definitions.py
+++ b/qc_schema/dev/definitions.py
@@ -74,7 +74,6 @@ definitions["basis_electron_shell"] = {
                 "type": "integer",
                 "minimum": 0
             }
-
         },
         "shell_exponents": {
             "description": "Exponents for this contracted shell",
@@ -154,9 +153,8 @@ definitions["basis_ecp_potential"] = {
     }
 }
 
-
 definitions["basis_single_data"] = {
-    "description": "Data for a single element or atom in the basis set",
+    "description": "Data for a single atom/center in the basis set",
     "type": "object",
     "additionalProperties": False,
     "properties": {

--- a/qc_schema/dev/dev_schema.py
+++ b/qc_schema/dev/dev_schema.py
@@ -37,9 +37,20 @@ base_schema = {
                 },
                 "basis": {
                     "type": "string"
+                },
+                "basis_spec": {
+                    "$ref": "#/definitions/basis_spec"
                 }
             },
-            "required": ["method", "basis"],
+            "required": [ "method" ],
+            "oneOf": [
+                {
+                    "required": ["basis"]
+                },
+                {
+                    "required": ["basis_spec"]
+                }
+            ],
             "description": "The quantum chemistry model to be run."
         },
         "keywords": {

--- a/tests/basis/waterZr_energy_B3LYP_STO3G_DEF2_input.json
+++ b/tests/basis/waterZr_energy_B3LYP_STO3G_DEF2_input.json
@@ -1,0 +1,399 @@
+{
+  "schema_name": "QC_JSON",
+  "schema_version": "v0.1",
+  "molecule": {
+    "geometry": [
+      0.0,
+      0.0,
+      -0.1294769411935893,
+      0.0,
+      -1.494187339479985,
+      1.0274465079245698,
+      0.0,
+      1.494187339479985,
+      1.0274465079245698,
+      2.0,
+      2.0,
+      2.0
+    ],
+    "symbols": [
+      "O",
+      "H",
+      "H",
+      "Zr"
+    ]
+  },
+  "driver": "energy",
+  "model": {
+    "method": "B3LYP",
+    "basis_spec": {
+      "basis_set_description": "6-31G on all Hydrogen and Oxygen atoms",
+      "basis_set_elements": {
+        "1": {
+          "element_electron_shells": [
+            {
+              "shell_function_type": "gto",
+              "shell_harmonic_type": "spherical",
+              "shell_region": "valence",
+              "shell_angular_momentum": [
+                0
+              ],
+              "shell_exponents": [
+                "3.42525091",
+                "0.62391373",
+                "0.16885540"
+              ],
+              "shell_coefficients": [
+                [
+                  "0.15432897",
+                  "0.53532814",
+                  "0.44463454"
+                ]
+              ]
+            }
+          ]
+        },
+        "8": {
+          "element_electron_shells": [
+            {
+              "shell_function_type": "gto",
+              "shell_harmonic_type": "spherical",
+              "shell_region": "valence",
+              "shell_angular_momentum": [
+                0
+              ],
+              "shell_exponents": [
+                "130.70932",
+                "23.808861",
+                "6.4436083"
+              ],
+              "shell_coefficients": [
+                [
+                  "0.15432897",
+                  "0.53532814",
+                  "0.44463454"
+                ]
+              ]
+            },
+            {
+              "shell_function_type": "gto",
+              "shell_harmonic_type": "spherical",
+              "shell_region": "valence",
+              "shell_angular_momentum": [
+                0,
+                1
+              ],
+              "shell_exponents": [
+                "5.0331513",
+                "1.1695961",
+                "0.3803890"
+              ],
+              "shell_coefficients": [
+                [
+                  "-0.09996723",
+                  "0.39951283",
+                  "0.70011547"
+                ],
+                [
+                  "0.15591627",
+                  "0.60768372",
+                  "0.39195739"
+                ]
+              ]
+            }
+          ]
+        }
+      },
+      "basis_set_atoms": {
+        "4": {
+          "element_electron_shells": [
+            {
+              "shell_function_type": "gto",
+              "shell_harmonic_type": "spherical",
+              "shell_region": "valence",
+              "shell_angular_momentum": [
+                0
+              ],
+              "shell_exponents": [
+                "11.000000000",
+                "9.5000000000",
+                "3.6383667759",
+                "0.76822026698",
+                "0.34036824036",
+                "0.75261298085E-01",
+                "0.30131404705E-01"
+              ],
+              "shell_coefficients": [
+                [
+                  "-0.19075595257",
+                  "0.33895588754",
+                  "0.0000000",
+                  "0.0000000",
+                  "0.0000000",
+                  "0.0000000",
+                  "0.0000000"
+                ],
+                [
+                  "0.0000000",
+                  "0.0000000",
+                  "1.0000000000",
+                  "0.0000000",
+                  "0.0000000",
+                  "0.0000000",
+                  "0.0000000"
+                ],
+                [
+                  "0.0000000",
+                  "0.0000000",
+                  "0.0000000",
+                  "1.0000000000",
+                  "0.0000000",
+                  "0.0000000",
+                  "0.0000000"
+                ],
+                [
+                  "0.0000000",
+                  "0.0000000",
+                  "0.0000000",
+                  "0.0000000",
+                  "1.0000000000",
+                  "0.0000000",
+                  "0.0000000"
+                ],
+                [
+                  "0.0000000",
+                  "0.0000000",
+                  "0.0000000",
+                  "0.0000000",
+                  "0.0000000",
+                  "1.0000000000",
+                  "0.0000000"
+                ],
+                [
+                  "0.0000000",
+                  "0.0000000",
+                  "0.0000000",
+                  "0.0000000",
+                  "0.0000000",
+                  "0.0000000",
+                  "1.0000000000"
+                ]
+              ]
+            },
+            {
+              "shell_function_type": "gto",
+              "shell_harmonic_type": "spherical",
+              "shell_region": "valence",
+              "shell_angular_momentum": [
+                1
+              ],
+              "shell_exponents": [
+                "8.6066305543",
+                "4.4400979958",
+                "1.1281026946",
+                "0.54346076310",
+                "0.25022406048",
+                "0.85000000000E-01",
+                "0.29000000000E-01"
+              ],
+              "shell_coefficients": [
+                [
+                  "0.40404260236E-01",
+                  "-0.21187745201",
+                  "0.49164266891",
+                  "0.57303370658",
+                  "0.0000000",
+                  "0.0000000",
+                  "0.0000000"
+                ],
+                [
+                  "0.0000000",
+                  "0.0000000",
+                  "0.0000000",
+                  "0.0000000",
+                  "1.0000000000",
+                  "0.0000000",
+                  "0.0000000"
+                ],
+                [
+                  "0.0000000",
+                  "0.0000000",
+                  "0.0000000",
+                  "0.0000000",
+                  "0.0000000",
+                  "1.0000000000",
+                  "0.0000000"
+                ],
+                [
+                  "0.0000000",
+                  "0.0000000",
+                  "0.0000000",
+                  "0.0000000",
+                  "0.0000000",
+                  "0.0000000",
+                  "1.0000000000"
+                ]
+              ]
+            },
+            {
+              "shell_function_type": "gto",
+              "shell_harmonic_type": "spherical",
+              "shell_region": "valence",
+              "shell_angular_momentum": [
+                2
+              ],
+              "shell_exponents": [
+                "4.5567957795",
+                "1.2904939797",
+                "0.51646987222",
+                "0.19349797794",
+                "0.67309809967E-01"
+              ],
+              "shell_coefficients": [
+                [
+                  "-0.96190569023E-02",
+                  "0.20569990155",
+                  "0.41831381851",
+                  "0.0000000",
+                  "0.0000000"
+                ],
+                [
+                  "0.0000000",
+                  "0.0000000",
+                  "0.0000000",
+                  "1.0000000000",
+                  "0.0000000"
+                ],
+                [
+                  "0.0000000",
+                  "0.0000000",
+                  "0.0000000",
+                  "0.0000000",
+                  "1.0000000000"
+                ]
+              ]
+            },
+            {
+              "shell_function_type": "gto",
+              "shell_harmonic_type": "spherical",
+              "shell_region": "valence",
+              "shell_angular_momentum": [
+                3
+              ],
+              "shell_exponents": [
+                "0.3926100"
+              ],
+              "shell_coefficients": [
+                [
+                  "1.0000000"
+                ]
+              ]
+            }
+          ],
+          "element_ecp_electrons": 28,
+          "element_ecp": [
+            {
+              "potential_ecp_type": "scalar",
+              "potential_angular_momentum": [
+                3
+              ],
+              "potential_r_exponents": [
+                2,
+                2
+              ],
+              "potential_gaussian_exponents": [
+                "6.5842120",
+                "3.2921060"
+              ],
+              "potential_coefficients": [
+                [
+                  "-19.12219811",
+                  "-2.43637543"
+                ]
+              ]
+            },
+            {
+              "potential_ecp_type": "scalar",
+              "potential_angular_momentum": [
+                0
+              ],
+              "potential_r_exponents": [
+                2,
+                2,
+                2,
+                2
+              ],
+              "potential_gaussian_exponents": [
+                "7.4880494",
+                "3.7440247",
+                "6.5842120",
+                "3.2921060"
+              ],
+              "potential_coefficients": [
+                [
+                  "135.15384412",
+                  "15.55244130",
+                  "19.12219811",
+                  "2.43637543"
+                ]
+              ]
+            },
+            {
+              "potential_ecp_type": "scalar",
+              "potential_angular_momentum": [
+                1
+              ],
+              "potential_r_exponents": [
+                2,
+                2,
+                2,
+                2
+              ],
+              "potential_gaussian_exponents": [
+                "6.4453772",
+                "3.2226886",
+                "6.5842120",
+                "3.2921060"
+              ],
+              "potential_coefficients": [
+                [
+                  "87.78499167",
+                  "11.56406599",
+                  "19.12219811",
+                  "2.43637543"
+                ]
+              ]
+            },
+            {
+              "potential_ecp_type": "scalar",
+              "potential_angular_momentum": [
+                2
+              ],
+              "potential_r_exponents": [
+                2,
+                2,
+                2,
+                2
+              ],
+              "potential_gaussian_exponents": [
+                "4.6584472",
+                "2.3292236",
+                "6.5842120",
+                "3.2921060"
+              ],
+              "potential_coefficients": [
+                [
+                  "29.70100072",
+                  "5.53996847",
+                  "19.12219811",
+                  "2.43637543"
+                ]
+              ]
+            }
+          ]
+        }
+      }
+    }
+  },
+  "keywords": {}
+}

--- a/tests/basis/waterZr_energy_B3LYP_STO3G_DEF2_input.json
+++ b/tests/basis/waterZr_energy_B3LYP_STO3G_DEF2_input.json
@@ -28,12 +28,12 @@
     "method": "B3LYP",
     "basis_spec": {
       "basis_set_description": "6-31G on all Hydrogen and Oxygen atoms",
+      "basis_function_type": "gto",
+      "basis_harmonic_type": "spherical",
       "basis_set_elements": {
         "1": {
           "element_electron_shells": [
             {
-              "shell_function_type": "gto",
-              "shell_harmonic_type": "spherical",
               "shell_region": "valence",
               "shell_angular_momentum": [
                 0
@@ -56,8 +56,6 @@
         "8": {
           "element_electron_shells": [
             {
-              "shell_function_type": "gto",
-              "shell_harmonic_type": "spherical",
               "shell_region": "valence",
               "shell_angular_momentum": [
                 0
@@ -76,8 +74,6 @@
               ]
             },
             {
-              "shell_function_type": "gto",
-              "shell_harmonic_type": "spherical",
               "shell_region": "valence",
               "shell_angular_momentum": [
                 0,
@@ -108,8 +104,6 @@
         "3": {
           "element_electron_shells": [
             {
-              "shell_function_type": "gto",
-              "shell_harmonic_type": "spherical",
               "shell_region": "valence",
               "shell_angular_momentum": [
                 0
@@ -181,8 +175,6 @@
               ]
             },
             {
-              "shell_function_type": "gto",
-              "shell_harmonic_type": "spherical",
               "shell_region": "valence",
               "shell_angular_momentum": [
                 1
@@ -236,8 +228,6 @@
               ]
             },
             {
-              "shell_function_type": "gto",
-              "shell_harmonic_type": "spherical",
               "shell_region": "valence",
               "shell_angular_momentum": [
                 2
@@ -274,8 +264,6 @@
               ]
             },
             {
-              "shell_function_type": "gto",
-              "shell_harmonic_type": "spherical",
               "shell_region": "valence",
               "shell_angular_momentum": [
                 3

--- a/tests/basis/waterZr_energy_B3LYP_STO3G_DEF2_input.json
+++ b/tests/basis/waterZr_energy_B3LYP_STO3G_DEF2_input.json
@@ -105,7 +105,7 @@
         }
       },
       "basis_set_atoms": {
-        "4": {
+        "3": {
           "element_electron_shells": [
             {
               "shell_function_type": "gto",

--- a/tests/basis/water_energy_B3LYP_631G_input.json
+++ b/tests/basis/water_energy_B3LYP_631G_input.json
@@ -24,12 +24,12 @@
     "method": "B3LYP",
     "basis_spec": {
       "basis_set_description": "6-31G on all Hydrogen and Oxygen atoms",
+      "basis_function_type": "gto",
+      "basis_harmonic_type": "spherical",
       "basis_set_elements": {
         "1": {
           "element_electron_shells": [
             {
-              "shell_function_type": "gto",
-              "shell_harmonic_type": "cartesian",
               "shell_region": "valence",
               "shell_angular_momentum": [
                 0
@@ -48,8 +48,6 @@
               ]
             },
             {
-              "shell_function_type": "gto",
-              "shell_harmonic_type": "cartesian",
               "shell_region": "valence",
               "shell_angular_momentum": [
                 0
@@ -68,8 +66,6 @@
         "8": {
           "element_electron_shells": [
             {
-              "shell_function_type": "gto",
-              "shell_harmonic_type": "spherical",
               "shell_region": "valence",
               "shell_angular_momentum": [
                 0
@@ -94,8 +90,6 @@
               ]
             },
             {
-              "shell_function_type": "gto",
-              "shell_harmonic_type": "spherical",
               "shell_region": "valence",
               "shell_angular_momentum": [
                 0,
@@ -120,8 +114,6 @@
               ]
             },
             {
-              "shell_function_type": "gto",
-              "shell_harmonic_type": "spherical",
               "shell_region": "valence",
               "shell_angular_momentum": [
                 0,

--- a/tests/basis/water_energy_B3LYP_631G_input.json
+++ b/tests/basis/water_energy_B3LYP_631G_input.json
@@ -1,0 +1,148 @@
+{
+  "schema_name": "QC_JSON",
+  "schema_version": "v0.1",
+  "molecule": {
+    "geometry": [
+      0.0,
+      0.0,
+      -0.1294769411935893,
+      0.0,
+      -1.494187339479985,
+      1.0274465079245698,
+      0.0,
+      1.494187339479985,
+      1.0274465079245698
+    ],
+    "symbols": [
+      "O",
+      "H",
+      "H"
+    ]
+  },
+  "driver": "energy",
+  "model": {
+    "method": "B3LYP",
+    "basis_spec": {
+      "basis_set_description": "6-31G on all Hydrogen and Oxygen atoms",
+      "basis_set_elements": {
+        "1": {
+          "element_electron_shells": [
+            {
+              "shell_function_type": "gto",
+              "shell_harmonic_type": "cartesian",
+              "shell_region": "valence",
+              "shell_angular_momentum": [
+                0
+              ],
+              "shell_exponents": [
+                "18.731137",
+                "2.8253944",
+                "0.6401217"
+              ],
+              "shell_coefficients": [
+                [
+                  "0.0334946",
+                  "0.2347269",
+                  "0.8137573"
+                ]
+              ]
+            },
+            {
+              "shell_function_type": "gto",
+              "shell_harmonic_type": "cartesian",
+              "shell_region": "valence",
+              "shell_angular_momentum": [
+                0
+              ],
+              "shell_exponents": [
+                "0.1612778"
+              ],
+              "shell_coefficients": [
+                [
+                  "1.0000000"
+                ]
+              ]
+            }
+          ]
+        },
+        "8": {
+          "element_electron_shells": [
+            {
+              "shell_function_type": "gto",
+              "shell_harmonic_type": "spherical",
+              "shell_region": "valence",
+              "shell_angular_momentum": [
+                0
+              ],
+              "shell_exponents": [
+                "5484.6717000",
+                "825.2349500",
+                "188.0469600",
+                "52.9645000",
+                "16.8975700",
+                "5.7996353"
+              ],
+              "shell_coefficients": [
+                [
+                  "0.0018311",
+                  "0.0139501",
+                  "0.0684451",
+                  "0.2327143",
+                  "0.4701930",
+                  "0.3585209"
+                ]
+              ]
+            },
+            {
+              "shell_function_type": "gto",
+              "shell_harmonic_type": "spherical",
+              "shell_region": "valence",
+              "shell_angular_momentum": [
+                0,
+                1
+              ],
+              "shell_exponents": [
+                "15.5396160",
+                "3.5999336",
+                "1.0137618"
+              ],
+              "shell_coefficients": [
+                [
+                  "-0.1107775",
+                  "-0.1480263",
+                  "1.1307670"
+                ],
+                [
+                  "0.0708743",
+                  "0.3397528",
+                  "0.7271586"
+                ]
+              ]
+            },
+            {
+              "shell_function_type": "gto",
+              "shell_harmonic_type": "spherical",
+              "shell_region": "valence",
+              "shell_angular_momentum": [
+                0,
+                1
+              ],
+              "shell_exponents": [
+                "0.2700058"
+              ],
+              "shell_coefficients": [
+                [
+                  "1.0000000"
+                ],
+                [
+                  "1.0000000"
+                ]
+              ]
+            }
+          ]
+        }
+      }
+    }
+  },
+  "keywords": {}
+}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -32,4 +32,13 @@ def test_simple_output(version, testfile):
 
 
 
+### Test basis inputs
+basis_input = test_helpers.list_tests("basis", matcher="input")
 
+# Loop over all tests that should pass the tests
+@pytest.mark.parametrize("testfile", basis_input[0], ids=basis_input[1])
+@pytest.mark.parametrize("version", qc_schema.list_versions())
+def test_simple_input(version, testfile):
+
+    example = test_helpers.get_test(testfile)
+    qc_schema.validate(example, "input")


### PR DESCRIPTION
## Description
Adds the ability to completely specify the basis set in the schema

The current `basis` key under `model` can be used to specify a common basis set by name and is not modified by this PR.

A new key `basis_spec` is added that allows for detailed specification of an element-wide basis (ie, all carbon atoms) via `basis_set_elements`, and also per-atom or per-center specifications via `basis_set_atoms`. ECPs are supported.

The keys of `basis_set_elements` is the atomic Z number, while the keys of `basis_set_atoms` is zero-based index of the center in the molecule.

Several fields (such as `shell_function_type` and `shell_region`) are optional.

Two tests have been added in the `tests/basis` directory.

This PR has been built on top of PR #40, and uses a very similar structure to that found in the new Basis Set Exchange, which would allow for easy interoperation.

## Status
- [ ] Ready to go
