### PR TITLE
schema for vibrational analysis

### DIFF
--- a/qcschema/dev/molecule.py
+++ b/qcschema/dev/molecule.py
@@ -16,7 +16,7 @@ molecule = {
             }
         },
         "geometry": {
-            "description": "(3 * nat, ) vector of XYZ coordinates of the atoms.",
+            "description": "(3 * nat, ) vector of XYZ coordinates [a0] of the atoms.",
             "type": "array",
             "items": {
                 "type": "number"

--- a/qcschema/dev/procedures/harmonicvibrations.py
+++ b/qcschema/dev/procedures/harmonicvibrations.py
@@ -1,0 +1,123 @@
+"""
+The json-schema for the harmonic vibrational analysis definition
+"""
+harmvib = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "name": "qc_schema_harmvib",
+    "version": "dev",
+    "description": "The MolSSI Quantum Chemistry Harmonic Vibrational Analysis Schema",
+    "type": "object",
+    "properties": {
+        "omega": {
+            "description": "(nvib, ) for each vibration, frequency of vibration [cm^-1]; +/- for real/imaginary modes.",
+            "type": "array",
+            "items": {
+                "type": "number"
+            }
+        },
+        "q": {
+            "description":
+            "(nvib, 3 * nat) for each vibration, vector of XYZ displacements [a0 u^1/2] for normal mode, normalized mass-weighted.",
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "number",
+                }
+            }
+        },
+        "w": {
+            "description":
+            "(nvib, 3 * nat) for each vibration, vector of XYZ displacements [a0] for normal mode, un-mass-weighted.",
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "number",
+                }
+            }
+        },
+        "x": {
+            "description":
+            "(nvib, 3 * nat) for each vibration, vector of XYZ displacements [a0] for normal mode, normalized un-mass-weighted.",
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "number",
+                }
+            }
+        },
+        "degeneracy": {
+            "description": "(nvib, ) for each vibration, degree of degeneracy.",
+            "type": "array",
+            "items": {
+                "type": "number"
+                "multipleOf": 1.0,
+            }
+        },
+        "TRV": {
+            "description": "(nvib, ) for each vibration, translation/rotation/vibration classification: 'TR' or 'V' or '-' for partial.",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "gamma": {
+            "description": "(nvib, ) for each vibration, irreducible representation or None if unclassifiable.",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "mu": {
+            "description": "(nvib, ) for each vibration, reduced mass [u]; +/+ for real/imaginary modes.",
+            "type": "array",
+            "items": {
+                "type": "number"
+            }
+        },
+        "k": {
+            "description": "(nvib, ) for each vibration, force constant [mDyne/A]; +/- for real/imaginary modes.",
+            "type": "array",
+            "items": {
+                "type": "number"
+            }
+        },
+        "DQ0": {
+            "description": "(nvib, ) for each vibration, RMS deviation v=0 [a0 u^1/2]; +/0 for real/imaginary modes.",
+            "type": "array",
+            "items": {
+                "type": "number"
+            }
+        },
+        "Qtp0": {
+            "description": "(nvib, ) for each vibration, turning point v=0 [a0 u^1/2]; +/0 for real/imaginary modes.",
+            "type": "array",
+            "items": {
+                "type": "number"
+            }
+        },
+        "Xtp0": {
+            "description": "(nvib, ) for each vibration, turnin point v=0 [a0]; +/0 for real/imaginary modes.",
+            "type": "array",
+            "items": {
+                "type": "number"
+            }
+        },
+        "theta_vib": {
+            "description": "(nvib, ) for each vibration, characteristic temperature [K]; +/0 for real/imaginary modes.",
+            "type": "array",
+            "items": {
+                "type": "number"
+                "multipleOf": 1.0,
+            }
+        },
+        "provenance": {
+            "type": "object",
+            "$ref": "#/definitions/provenance"
+        }
+    },
+    "required": ["omega", "q"],
+    "description": "The solved results of a Hessian calculation"
+}


### PR DESCRIPTION
## Description
propose data structures for conveying a harmonic vibrational analysis

- [x] based upon https://github.com/psi4/psi4/blob/master/psi4/driver/qcdb/vib.py#L331-L359 . notable change is no complex frequencies to humor json.
- [x] there's some non-atomic units in there. they're pretty industry standard, but could be replaced by au equivalents (frequency and force constant)
- [ ] vibanal will need to own a molecule. haven't worked out how json does that yet
- [ ] I've listed dimension as `nvib`. in practice could be `ndof` for full Hessian, `nvib` for only vibrations (rotations/translations discarded or never computed), `?` for partial solutions (e.g., A2 only)

## Status
- [ ] Ready to go
