### PR TITLE
Active space extension

### DIFF
--- a/qcschema/dev/wavefunction/result_wavefunction.py
+++ b/qcschema/dev/wavefunction/result_wavefunction.py
@@ -29,6 +29,18 @@ result_wavefunction["density_b"] = {
 }
 
 
+result_wavefunction["density_mo_a"] = {
+    "type": "string",
+    "description": "Alpha-spin density in the MO basis of the primary return."
+}
+
+
+result_wavefunction["density_mo_b"] = {
+    "type": "string",
+    "description": "Beta-spin density in the MO basis of the primary return."
+}
+
+
 # Fock matrix
 result_wavefunction["fock_a"] = {
     "type": "string",
@@ -39,6 +51,18 @@ result_wavefunction["fock_a"] = {
 result_wavefunction["fock_b"] = {
     "type": "string",
     "description": "Beta-spin Fock matrix in the AO basis of the primary return."
+}
+
+
+result_wavefunction["fock_mo_a"] = {
+    "type": "string",
+    "description": "Alpha-spin Fock matrix in the MO basis of the primary return."
+}
+
+
+result_wavefunction["fock_mo_b"] = {
+    "type": "string",
+    "description": "Beta-spin Fock matrix in the MO basis of the primary return."
 }
 
 
@@ -90,4 +114,28 @@ result_wavefunction["eri_ba"] = {
 result_wavefunction["eri_bb"] = {
     "type": "string",
     "description": "Beta-beta-spin electron-repulsion integrals in the AO basis of the primary return."
+}
+
+
+result_wavefunction["eri_mo_aa"] = {
+    "type": "string",
+    "description": "Alpha-alpha-spin electron-repulsion integrals in the MO basis of the primary return."
+}
+
+
+result_wavefunction["eri_mo_ab"] = {
+    "type": "string",
+    "description": "Alpha-beta-spin electron-repulsion integrals in the MO basis of the primary return."
+}
+
+
+result_wavefunction["eri_mo_ba"] = {
+    "type": "string",
+    "description": "Beta-alpha-spin electron-repulsion integrals in the MO basis of the primary return."
+}
+
+
+result_wavefunction["eri_mo_bb"] = {
+    "type": "string",
+    "description": "Beta-beta-spin electron-repulsion integrals in the MO basis of the primary return."
 }

--- a/qcschema/dev/wavefunction/result_wavefunction.py
+++ b/qcschema/dev/wavefunction/result_wavefunction.py
@@ -66,3 +66,28 @@ result_wavefunction["occupations_b"] = {
     "type": "string",
     "description": "Beta-spin orbital occupations of the primary return."
 }
+
+
+# Electron-Repulsion Integrals
+result_wavefunction["eri_aa"] = {
+    "type": "string",
+    "description": "Alpha-alpha-spin electron-repulsion integrals in the AO basis of the primary return."
+}
+
+
+result_wavefunction["eri_ab"] = {
+    "type": "string",
+    "description": "Alpha-beta-spin electron-repulsion integrals in the AO basis of the primary return."
+}
+
+
+result_wavefunction["eri_ba"] = {
+    "type": "string",
+    "description": "Beta-alpha-spin electron-repulsion integrals in the AO basis of the primary return."
+}
+
+
+result_wavefunction["eri_bb"] = {
+    "type": "string",
+    "description": "Beta-beta-spin electron-repulsion integrals in the AO basis of the primary return."
+}

--- a/qcschema/dev/wavefunction/result_wavefunction.py
+++ b/qcschema/dev/wavefunction/result_wavefunction.py
@@ -93,27 +93,9 @@ result_wavefunction["occupations_b"] = {
 
 
 # Electron-Repulsion Integrals
-result_wavefunction["eri_aa"] = {
+result_wavefunction["eri"] = {
     "type": "string",
-    "description": "Alpha-alpha-spin electron-repulsion integrals in the AO basis of the primary return."
-}
-
-
-result_wavefunction["eri_ab"] = {
-    "type": "string",
-    "description": "Alpha-beta-spin electron-repulsion integrals in the AO basis of the primary return."
-}
-
-
-result_wavefunction["eri_ba"] = {
-    "type": "string",
-    "description": "Beta-alpha-spin electron-repulsion integrals in the AO basis of the primary return."
-}
-
-
-result_wavefunction["eri_bb"] = {
-    "type": "string",
-    "description": "Beta-beta-spin electron-repulsion integrals in the AO basis of the primary return."
+    "description": "Electron-repulsion integrals in the AO basis of the primary return."
 }
 
 

--- a/qcschema/dev/wavefunction/scf_wavefunction.py
+++ b/qcschema/dev/wavefunction/scf_wavefunction.py
@@ -37,6 +37,22 @@ scf_wavefunction["scf_density_b"] = {
 }
 
 
+scf_wavefunction["scf_density_mo_a"] = {
+    "type": "array",
+    "description": "SCF alpha-spin density in the MO basis.",
+    "items": {"type": "number"},
+    "shape": ["nmo", "nmo"]
+}
+
+
+scf_wavefunction["scf_density_mo_b"] = {
+    "type": "array",
+    "description": "SCF beta-spin density in the MO basis.",
+    "items": {"type": "number"},
+    "shape": ["nmo", "nmo"]
+}
+
+
 # Fock matrix
 scf_wavefunction["scf_fock_a"] = {
     "type": "array",
@@ -51,6 +67,22 @@ scf_wavefunction["scf_fock_b"] = {
     "description": "SCF beta-spin Fock matrix in the AO basis.",
     "items": {"type": "number"},
     "shape": ["nao", "nao"]
+}
+
+
+scf_wavefunction["scf_fock_mo_a"] = {
+    "type": "array",
+    "description": "SCF alpha-spin Fock matrix in the MO basis.",
+    "items": {"type": "number"},
+    "shape": ["nmo", "nmo"]
+}
+
+
+scf_wavefunction["scf_fock_mo_b"] = {
+    "type": "array",
+    "description": "SCF beta-spin Fock matrix in the MO basis.",
+    "items": {"type": "number"},
+    "shape": ["nmo", "nmo"]
 }
 
 
@@ -150,4 +182,36 @@ scf_wavefunction["scf_eri_bb"] = {
     "description": "SCF beta-beta-spin electron-repulsion integrals in the AO basis.",
     "items": {"type": "number"},
     "shape": ["nao", "nao", "nao", "nao"],
+}
+
+
+scf_wavefunction["scf_eri_mo_aa"] = {
+    "type": "array",
+    "description": "SCF alpha-alpha-spin electron-repulsion integrals in the MO basis.",
+    "items": {"type": "number"},
+    "shape": ["nmo", "nmo", "nmo", "nmo"],
+}
+
+
+scf_wavefunction["scf_eri_mo_ab"] = {
+    "type": "array",
+    "description": "SCF alpha-beta-spin electron-repulsion integrals in the MO basis.",
+    "items": {"type": "number"},
+    "shape": ["nmo", "nmo", "nmo", "nmo"],
+}
+
+
+scf_wavefunction["scf_eri_mo_ba"] = {
+    "type": "array",
+    "description": "SCF beta-alpha-spin electron-repulsion integrals in the MO basis.",
+    "items": {"type": "number"},
+    "shape": ["nmo", "nmo", "nmo", "nmo"],
+}
+
+
+scf_wavefunction["scf_eri_mo_bb"] = {
+    "type": "array",
+    "description": "SCF beta-beta-spin electron-repulsion integrals in the MO basis.",
+    "items": {"type": "number"},
+    "shape": ["nmo", "nmo", "nmo", "nmo"],
 }

--- a/qcschema/dev/wavefunction/scf_wavefunction.py
+++ b/qcschema/dev/wavefunction/scf_wavefunction.py
@@ -119,3 +119,35 @@ scf_wavefunction["scf_occupations_b"] = {
     "shape": ["nmo"]
 }
 
+
+# Electron-Repulsion Integrals
+scf_wavefunction["scf_eri_aa"] = {
+    "type": "array",
+    "description": "SCF alpha-alpha-spin electron-repulsion integrals in the AO basis.",
+    "items": {"type": "number"},
+    "shape": ["nao", "nao", "nao", "nao"],
+}
+
+
+scf_wavefunction["scf_eri_ab"] = {
+    "type": "array",
+    "description": "SCF alpha-beta-spin electron-repulsion integrals in the AO basis.",
+    "items": {"type": "number"},
+    "shape": ["nao", "nao", "nao", "nao"],
+}
+
+
+scf_wavefunction["scf_eri_ba"] = {
+    "type": "array",
+    "description": "SCF beta-alpha-spin electron-repulsion integrals in the AO basis.",
+    "items": {"type": "number"},
+    "shape": ["nao", "nao", "nao", "nao"],
+}
+
+
+scf_wavefunction["scf_eri_bb"] = {
+    "type": "array",
+    "description": "SCF beta-beta-spin electron-repulsion integrals in the AO basis.",
+    "items": {"type": "number"},
+    "shape": ["nao", "nao", "nao", "nao"],
+}

--- a/qcschema/dev/wavefunction/scf_wavefunction.py
+++ b/qcschema/dev/wavefunction/scf_wavefunction.py
@@ -153,33 +153,9 @@ scf_wavefunction["scf_occupations_b"] = {
 
 
 # Electron-Repulsion Integrals
-scf_wavefunction["scf_eri_aa"] = {
+scf_wavefunction["scf_eri"] = {
     "type": "array",
-    "description": "SCF alpha-alpha-spin electron-repulsion integrals in the AO basis.",
-    "items": {"type": "number"},
-    "shape": ["nao", "nao", "nao", "nao"],
-}
-
-
-scf_wavefunction["scf_eri_ab"] = {
-    "type": "array",
-    "description": "SCF alpha-beta-spin electron-repulsion integrals in the AO basis.",
-    "items": {"type": "number"},
-    "shape": ["nao", "nao", "nao", "nao"],
-}
-
-
-scf_wavefunction["scf_eri_ba"] = {
-    "type": "array",
-    "description": "SCF beta-alpha-spin electron-repulsion integrals in the AO basis.",
-    "items": {"type": "number"},
-    "shape": ["nao", "nao", "nao", "nao"],
-}
-
-
-scf_wavefunction["scf_eri_bb"] = {
-    "type": "array",
-    "description": "SCF beta-beta-spin electron-repulsion integrals in the AO basis.",
+    "description": "SCF electron-repulsion integrals in the AO basis.",
     "items": {"type": "number"},
     "shape": ["nao", "nao", "nao", "nao"],
 }


### PR DESCRIPTION
## Description
I would like to extend this schema to support active space-based embedding techniques.
For this to work efficiently, we need to add two additions to the schema:
1. sending MO data directly rather than AO data, in order to allow the minimal set of information to be transferred (i.e. only the active MOs instead of the full AO set)
2. add fields for the 2-body terms (electron repulsion integrals; short: eri). This will enable this schema to be used to interface two codes where e.g. one of them does not support eri-computation on-the-fly.

## Questions
- [ ] How can we generalize the basis in which a matrix is provided in? I naively added some `_mo_` named keywords but I don't think this scales well for the future.
- [ ] Can we encode symmetry information for the `eri` terms? This would permit not having to send `O(N^4)` numbers when up to 8-fold symmetry could be exploited.

## Status
- [ ] Open for discussion
